### PR TITLE
Optimize; we only care *if* we've found a match, not what they are.

### DIFF
--- a/lib/Perl/Critic/Policy/TryTiny/RequireUse.pm
+++ b/lib/Perl/Critic/Policy/TryTiny/RequireUse.pm
@@ -26,7 +26,7 @@ sub violates {
 
     my $try_package = _find_package( $try );
 
-    my $includes = $doc->find(sub{
+    my $included = $doc->find_any(sub{
         $_[1]->isa('PPI::Statement::Include')
             and
         defined( $_[1]->module() )
@@ -46,9 +46,9 @@ sub violates {
         $_[1]->type() eq 'use'
             and
         _find_package( $_[1] ) eq $try_package
-    }) || [];
+    });
 
-    return if @$includes;
+    return if $included;
 
     return $self->violation( $DESC, $EXPL, $try );
 }
@@ -65,8 +65,8 @@ sub _find_package {
             return $element->namespace() if $element->ancestor_of( $original );
 
             # If we've hit a non-block package then thats our package.
-            my $blocks = $element->find('PPI::Structure::Block') || [];
-            return $element->namespace() if !@$blocks;
+            my $blocks = $element->find_any('PPI::Structure::Block');
+            return $element->namespace() if !$blocks;
         }
 
         # Keep walking backwards until we match the above logic or we get to


### PR DESCRIPTION
We don't do any further examination of the nodes returned via the call
to `->find(...)`, so we can optimize these searches by returning
immediately if we have found a given match.